### PR TITLE
Loading Indicator shouldn't disappear when first token is received

### DIFF
--- a/apps/web/src/features/chat/components/thread/index.tsx
+++ b/apps/web/src/features/chat/components/thread/index.tsx
@@ -220,7 +220,6 @@ export function Thread() {
     dragOver,
     handlePaste,
   } = useFileUpload();
-  const [firstTokenReceived, setFirstTokenReceived] = useState(false);
 
   const { apiKeys } = useApiKeys();
 
@@ -265,17 +264,6 @@ export function Thread() {
 
   // TODO: this should be part of the useStream hook
   const prevMessageLength = useRef(0);
-  useEffect(() => {
-    if (
-      messages.length !== prevMessageLength.current &&
-      messages?.length &&
-      messages[messages.length - 1].type === "ai"
-    ) {
-      setFirstTokenReceived(true);
-    }
-
-    prevMessageLength.current = messages.length;
-  }, [messages]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -291,7 +279,6 @@ export function Thread() {
       isLoading
     )
       return;
-    setFirstTokenReceived(false);
 
     const newHumanMessage: Message = {
       id: uuidv4(),
@@ -346,7 +333,6 @@ export function Thread() {
 
     // Do this so the loading state is correct
     prevMessageLength.current = prevMessageLength.current - 1;
-    setFirstTokenReceived(false);
     stream.submit(undefined, {
       checkpoint: parentCheckpoint,
       streamMode: ["values"],

--- a/apps/web/src/features/chat/components/thread/index.tsx
+++ b/apps/web/src/features/chat/components/thread/index.tsx
@@ -262,9 +262,6 @@ export function Thread() {
     }
   }, [stream.error]);
 
-  // TODO: this should be part of the useStream hook
-  const prevMessageLength = useRef(0);
-
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
 
@@ -331,8 +328,6 @@ export function Thread() {
     if (!agentId) return;
     const { getAgentConfig } = useConfigStore.getState();
 
-    // Do this so the loading state is correct
-    prevMessageLength.current = prevMessageLength.current - 1;
     stream.submit(undefined, {
       checkpoint: parentCheckpoint,
       streamMode: ["values"],

--- a/apps/web/src/features/chat/components/thread/index.tsx
+++ b/apps/web/src/features/chat/components/thread/index.tsx
@@ -410,7 +410,7 @@ export function Thread() {
                   handleRegenerate={handleRegenerate}
                 />
               )}
-              {isLoading && !firstTokenReceived && <AssistantMessageLoading />}
+              {isLoading && <AssistantMessageLoading />}
               {errorMessage && (
                 <Alert variant="destructive">
                   <AlertCircle className="size-4" />


### PR DESCRIPTION
Edit loading indicator to show as long as stream is still running

**Reasoning**
For Deep Research, information comes back in waves. We send a message to the user that we have "started" research. This triggers that the first token has returned, but then it looks like the researcher isn't doing anything.

I don't think it's a big deal to have the indicator there while tokens are still coming back. Maybe we can change the indicator to a spinner? But I think very important to show that the stream is still running (even though tokens aren't actively coming back)