### PR TITLE
fix: Removed extra slash in mcp URL

### DIFF
--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -125,7 +125,7 @@ The next step in setting up Open Agent Platform is to deploy and configure your 
   <Step title="Configure MCP Server URL">
     Set your MCP server URL inside the `apps/web/` directory (ensure it does not end with `/mcp`. This will be auto-applied by OAP):
     ```bash
-    NEXT_PUBLIC_MCP_SERVER_URL="https://api.arcade.dev/v1/mcps/arcade-anon/"
+    NEXT_PUBLIC_MCP_SERVER_URL="https://api.arcade.dev/v1/mcps/arcade-anon"
     ```
   </Step>
   <Step title="Configure Authentication (if required)">


### PR DESCRIPTION
Removed the slash from the example MCP URL to fix the path error. 