### PR TITLE
feat: Implement last selected agent functionality in chat feature

### DIFF
--- a/apps/web/src/hooks/use-last-selected-agent.tsx
+++ b/apps/web/src/hooks/use-last-selected-agent.tsx
@@ -1,0 +1,16 @@
+import { useLocalStorage } from "./use-local-storage";
+
+/**
+ * Custom hook to manage the last selected agent ID in local storage.
+ * 
+ * @returns A tuple containing the last selected agent ID and a function to update it.
+ * The agent ID is stored in the format "agentId:deploymentId"
+ */
+export function useLastSelectedAgent(): [string | null, (agentId: string | null) => void] {
+  const [lastSelectedAgent, setLastSelectedAgent] = useLocalStorage<string | null>(
+    "oap-last-selected-agent",
+    null
+  );
+
+  return [lastSelectedAgent, setLastSelectedAgent];
+}


### PR DESCRIPTION
Issue #403

- Added a custom hook `useLastSelectedAgent` to manage the last selected agent ID in local storage.
- Updated `NewThreadButton` and `StreamProvider` components to utilize the last selected agent, allowing for persistence across sessions.
- Enhanced agent selection logic to fallback to the last selected agent if available, improving user experience.