### PR TITLE
fix: Bug with inbox query params when switching agents

### DIFF
--- a/apps/web-v2/src/features/agent-inbox/components/generic-inbox-item.tsx
+++ b/apps/web-v2/src/features/agent-inbox/components/generic-inbox-item.tsx
@@ -34,20 +34,19 @@ export function GenericInboxItem<
     VIEW_STATE_THREAD_QUERY_PARAM,
     parseAsString,
   );
-  const [agentInboxId] = useQueryState("agentInbox");
+  const [agentId] = useQueryState("agentId");
+  const [deploymentId] = useQueryState("deploymentId");
 
   const handleOpenInStudio = () => {
-    if (!agentInboxId) {
+    if (!agentId || !deploymentId) {
       toast.error("No agent inbox selected.", {
         duration: 5000,
       });
       return;
     }
 
-    const [assistantId, deploymentId] = agentInboxId.split(":");
-
     const studioUrl = constructOpenInStudioURL(
-      assistantId,
+      agentId,
       deploymentId,
       threadData.thread.thread_id,
     );
@@ -102,7 +101,7 @@ export function GenericInboxItem<
       <div
         className={cn(
           "col-span-6 flex items-center justify-start gap-2",
-          !agentInboxId && "col-span-9",
+          !agentId || (!deploymentId && "col-span-9"),
         )}
       >
         <p className="text-sm font-semibold text-black">Thread ID:</p>
@@ -112,7 +111,7 @@ export function GenericInboxItem<
         />
       </div>
 
-      {agentInboxId && (
+      {agentId && deploymentId && (
         <div className="col-span-2 flex items-center">
           <Button
             size="sm"
@@ -128,7 +127,7 @@ export function GenericInboxItem<
       <div
         className={cn(
           "col-span-2 flex items-center",
-          !agentInboxId && "col-start-10",
+          !agentId || (!deploymentId && "col-start-10"),
         )}
       >
         <InboxItemStatuses status={threadData.status} />

--- a/apps/web-v2/src/features/agent-inbox/components/thread-actions-view.tsx
+++ b/apps/web-v2/src/features/agent-inbox/components/thread-actions-view.tsx
@@ -118,7 +118,8 @@ export function ThreadActionsView<
   handleShowSidePanel,
   setThreadData,
 }: ThreadActionsViewProps<ThreadValues>) {
-  const [agentInboxId] = useQueryState("agentInbox");
+  const [agentId] = useQueryState("agentId");
+  const [deploymentId] = useQueryState("deploymentId");
   const { fetchSingleThread } = useThreadsContext<ThreadValues>();
   const [, setQueryParams] = useQueryStates({
     [VIEW_STATE_THREAD_QUERY_PARAM]: parseAsString,
@@ -143,11 +144,16 @@ export function ThreadActionsView<
     setThreadData,
   });
 
-  const handleOpenInStudio = (id: string) => {
-    const [assistantId, deploymentId] = id.split(":");
+  const handleOpenInStudio = () => {
+    if (!agentId || !deploymentId) {
+      toast.error("No agent inbox selected.", {
+        duration: 5000,
+      });
+      return;
+    }
 
     const studioUrl = constructOpenInStudioURL(
-      assistantId,
+      agentId,
       deploymentId,
       threadData.thread.thread_id,
     );
@@ -185,7 +191,7 @@ export function ThreadActionsView<
 
   const handleRefreshThread = async () => {
     // Use selectedInbox here as well
-    if (!agentInboxId) {
+    if (!agentId || !deploymentId) {
       toast.error("No agent inbox selected.", { richColors: true });
       return;
     }
@@ -272,12 +278,12 @@ export function ThreadActionsView<
             </div>
             {/* Right-side controls with ButtonGroup */}
             <div className="flex flex-row items-center justify-start gap-2">
-              {agentInboxId && (
+              {agentId && deploymentId && (
                 <Button
                   size="sm"
                   variant="outline"
                   className="flex items-center gap-1 bg-white"
-                  onClick={() => handleOpenInStudio(agentInboxId)}
+                  onClick={() => handleOpenInStudio()}
                 >
                   Studio
                 </Button>
@@ -352,12 +358,12 @@ export function ThreadActionsView<
             <ThreadIdCopyable threadId={threadData.thread.thread_id} />
           </div>
           <div className="flex flex-row items-center justify-start gap-2">
-            {agentInboxId && (
+            {agentId && deploymentId && (
               <Button
                 size="sm"
                 variant="outline"
                 className="flex items-center gap-1 bg-white"
-                onClick={() => handleOpenInStudio(agentInboxId)}
+                onClick={() => handleOpenInStudio()}
               >
                 Studio
               </Button>
@@ -474,12 +480,12 @@ export function ThreadActionsView<
           <ThreadIdCopyable threadId={threadData.thread.thread_id} />
         </div>
         <div className="flex flex-row items-center justify-start gap-2">
-          {agentInboxId && (
+          {agentId && deploymentId && (
             <Button
               size="sm"
               variant="outline"
               className="flex items-center gap-1 bg-white"
-              onClick={() => handleOpenInStudio(agentInboxId)}
+              onClick={() => handleOpenInStudio()}
             >
               Studio
             </Button>

--- a/apps/web-v2/src/features/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/apps/web-v2/src/features/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -76,7 +76,8 @@ export default function useInterruptedActions<
     INBOX_PARAM,
     parseAsString.withDefault("interrupted"),
   );
-  const [agentInboxId] = useQueryState("agentInbox");
+  const [agentId] = useQueryState("agentId");
+  const [deploymentId] = useQueryState("deploymentId");
   const [, setSelectedThreadId] = useQueryState(
     VIEW_STATE_THREAD_QUERY_PARAM,
     parseAsString,
@@ -135,8 +136,8 @@ export default function useInterruptedActions<
     e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent,
   ) => {
     e.preventDefault();
-    if (!agentInboxId) {
-      toast.error("No agent inbox ID found");
+    if (!agentId || !deploymentId) {
+      toast.error("No agent ID or deployment ID found");
       return;
     }
     if (!threadData || !setThreadData) {
@@ -273,9 +274,9 @@ export default function useInterruptedActions<
         setCurrentNode("");
         setStreaming(false);
 
-        if (!agentInboxId) {
+        if (!agentId || !deploymentId) {
           console.warn(
-            "No agentInboxId found after successful submission, redirecting to inbox",
+            "No agent ID or deployment ID found after successful submission, redirecting to inbox",
           );
           await setSelectedThreadId(null);
           setStreamFinished(false);
@@ -285,7 +286,6 @@ export default function useInterruptedActions<
         // Fetch updated thread data BEFORE any navigation/redirect
         const updatedThreadData = await fetchSingleThread(
           threadData.thread.thread_id,
-          agentInboxId,
         );
 
         if (updatedThreadData && updatedThreadData?.status === "interrupted") {
@@ -293,9 +293,8 @@ export default function useInterruptedActions<
           setThreadData(updatedThreadData as ThreadData<ThreadValues>);
         } else {
           // Thread is resolved or no longer interrupted, redirect to inbox
-          const [assistantId, deploymentId] = agentInboxId.split(":");
           if (session) {
-            await fetchThreads(assistantId, deploymentId, session);
+            await fetchThreads(agentId, deploymentId, session);
           }
           await setSelectedThreadId(null);
         }
@@ -317,8 +316,8 @@ export default function useInterruptedActions<
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
     e.preventDefault();
-    if (!agentInboxId) {
-      toast.error("No agent inbox ID found");
+    if (!agentId || !deploymentId) {
+      toast.error("No agent ID or deployment ID found");
       return;
     }
     if (!threadData || !setThreadData) {
@@ -341,10 +340,9 @@ export default function useInterruptedActions<
     initialHumanInterruptEditValue.current = {};
 
     await sendHumanResponse(threadData.thread.thread_id, [ignoreResponse]);
-    const [assistantId, deploymentId] = agentInboxId.split(":");
     // Re-fetch threads before routing back so the inbox is up to date
     if (session) {
-      await fetchThreads(assistantId, deploymentId, session);
+      await fetchThreads(agentId, deploymentId, session);
     }
 
     setLoading(false);
@@ -359,8 +357,8 @@ export default function useInterruptedActions<
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
     e.preventDefault();
-    if (!agentInboxId) {
-      toast.error("No agent inbox ID found");
+    if (!agentId || !deploymentId) {
+      toast.error("No agent ID or deployment ID found");
       return;
     }
     if (!threadData || !setThreadData) {
@@ -376,9 +374,8 @@ export default function useInterruptedActions<
     initialHumanInterruptEditValue.current = {};
 
     await ignoreThread(threadData.thread.thread_id);
-    const [assistantId, deploymentId] = agentInboxId.split(":");
     if (session) {
-      await fetchThreads(assistantId, deploymentId, session);
+      await fetchThreads(agentId, deploymentId, session);
     }
 
     setLoading(false);


### PR DESCRIPTION
Removes all instances of using `agentInbox` query param, and instead uses `agentId` and `deploymentId` like the rest of the app